### PR TITLE
Improve local recovery tests

### DIFF
--- a/scripts/provider.service.ts
+++ b/scripts/provider.service.ts
@@ -1,21 +1,59 @@
 import * as zksync from "zksync-web3";
+import { TransactionResponse } from "zksync-web3/build/src/types";
 import { getEnv } from "./config.service";
+import { getDeployer } from "./deployer.service";
 
-export const waitForTimestamp = async (deadline: number, provider: zksync.Provider, timeout: number = 60) => {
+type seconds = number;
+
+export const waitForTimestamp = async (deadline: seconds, provider: zksync.Provider, timeout: seconds = 60) => {
   if (getEnv() === "local") {
-    throw new Error("Not implemented: evm_increaseTime");
-    await provider.send("evm_increaseTime", [deadline]);
-    return;
+    return waitForTimestampLocal(deadline, provider, timeout);
   }
+  return waitForTimestampPublic(deadline, provider, timeout);
+};
+
+export const waitForTimestampLocal = async (deadline: seconds, provider: zksync.Provider, timeout: seconds = 60) => {
+  const { deployer, deployerAddress } = getDeployer();
+  while (true) {
+    const block = await provider.getBlock(await provider.getBlockNumber());
+    if (deadline - block.timestamp > timeout) {
+      throw new Error("Deadline too long");
+    }
+    if (block.timestamp >= deadline) {
+      return;
+    }
+    // need to send dummy transactions to mine blocks
+    // TODO: use evm_increaseTime when available
+    const response = await deployer.zkWallet.sendTransaction({ to: deployerAddress, value: 1 });
+    await response.wait();
+    await sleep(1);
+  }
+};
+
+export const waitForTimestampPublic = async (deadline: seconds, provider: zksync.Provider, timeout: seconds = 60) => {
   return new Promise<void>((resolve, reject) => {
-    provider.on("block", async (blockNumber: number) => {
+    const handleBlock = async (blockNumber: seconds) => {
       const block = await provider.getBlock(blockNumber);
-      if (deadline - block.timestamp >= 5 * 60 * 60) {
-        reject("Not waiting more than 5 minutes for deadline");
-      } else if (block.timestamp >= deadline) {
+      if (block.timestamp >= deadline) {
+        provider.off("block", handleBlock);
         resolve();
       }
-    });
-    setTimeout(reject, timeout * 1000);
+    };
+    provider.on("block", handleBlock);
+    setTimeout(() => {
+      provider.off("block", handleBlock);
+      reject("Timed out waiting for timestamp");
+    }, timeout * 1000);
   });
 };
+
+export const waitForL1BatchBlock = async (response: TransactionResponse, provider: zksync.Provider) => {
+  const receipt = await response.waitFinalize();
+  const range = await provider.getL1BatchBlockRange(receipt.l1BatchNumber);
+  if (!range) {
+    throw new Error("Batch not found");
+  }
+  return await provider.getBlock(range[0]);
+};
+
+export const sleep = (seconds: seconds) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));


### PR DESCRIPTION
- Wait for L1 batch block to get correct timestamp for testing security period
- When waiting for a timestamp using the local node, periodically send dummy transactions in order to force finalization of blocks 