### PR TITLE
Use common test fixtures

### DIFF
--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -1,31 +1,26 @@
-import "@nomicfoundation/hardhat-chai-matchers";
-import "@nomiclabs/hardhat-ethers";
 import { expect } from "chai";
 import { BytesLike, PopulatedTransaction } from "ethers";
 import { ethers } from "hardhat";
 import * as zksync from "zksync-web3";
 import { computeCreate2AddressFromSdk, connect, deployAccount } from "../src/account.service";
-import { checkDeployer, CustomDeployer, getDeployer } from "../src/deployer.service";
+import { checkDeployer, CustomDeployer } from "../src/deployer.service";
 import { deployTestDapp, getTestInfrastructure } from "../src/infrastructure.service";
 import { ArgentInfrastructure } from "../src/model";
 import { ArgentSigner, TransactionRequest } from "../src/signer.service";
 import { ArgentAccount, IMulticall, TestDapp, UpgradedArgentAccount } from "../typechain-types";
-import { TransactionStruct } from "../typechain-types/@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IAccount";
-
-const { AddressZero } = ethers.constants;
-
-const owner = zksync.Wallet.createRandom();
-const guardian = zksync.Wallet.createRandom();
-const newOwner = zksync.Wallet.createRandom();
-const wrongOwner = zksync.Wallet.createRandom();
-const wrongGuardian = zksync.Wallet.createRandom();
-
-const ownerAddress = owner.address;
-const guardianAddress = guardian.address;
-const { deployer, deployerAddress, provider } = getDeployer();
-
-console.log(`owner private key: ${owner.privateKey} (${ownerAddress})`);
-console.log(`guardian private key: ${guardian.privateKey} (${guardianAddress})`);
+import { TransactionStruct } from "../typechain-types/contracts/ArgentAccount";
+import {
+  AddressZero,
+  deployer,
+  deployerAddress,
+  guardian,
+  guardianAddress,
+  owner,
+  ownerAddress,
+  provider,
+  wrongGuardian,
+  wrongOwner,
+} from "./fixtures";
 
 const makeCall = ({ to = AddressZero, data = "0x" }: PopulatedTransaction): IMulticall.CallStruct => ({
   to,
@@ -267,6 +262,8 @@ describe("Argent account", () => {
     });
 
     describe("Calling the dapp without using a guardian", () => {
+      const newOwner = zksync.Wallet.createRandom();
+
       before(async () => {
         account = await deployAccount({
           argent,

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,19 @@
+import "@nomicfoundation/hardhat-chai-matchers";
+import "@nomiclabs/hardhat-ethers";
+import { ethers } from "hardhat";
+import * as zksync from "zksync-web3";
+import { getDeployer } from "../src/deployer.service";
+
+export const owner = zksync.Wallet.createRandom();
+export const guardian = zksync.Wallet.createRandom();
+export const wrongOwner = zksync.Wallet.createRandom();
+export const wrongGuardian = zksync.Wallet.createRandom();
+
+export const ownerAddress = owner.address;
+export const guardianAddress = guardian.address;
+
+export const { AddressZero } = ethers.constants;
+export const { deployer, deployerAddress, provider } = getDeployer();
+
+console.log(`owner private key: ${owner.privateKey} (${ownerAddress})`);
+console.log(`guardian private key: ${guardian.privateKey} (${guardianAddress})`);

--- a/test/paymaster-single-signature.test.ts
+++ b/test/paymaster-single-signature.test.ts
@@ -1,18 +1,13 @@
-import "@nomicfoundation/hardhat-chai-matchers";
-import "@nomiclabs/hardhat-ethers";
 import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import * as zksync from "zksync-web3";
 import { deployAccount } from "../src/account.service";
-import { checkDeployer, getDeployer } from "../src/deployer.service";
+import { checkDeployer } from "../src/deployer.service";
 import { getTestInfrastructure } from "../src/infrastructure.service";
 import { ArgentInfrastructure } from "../src/model";
 import { ArgentAccount } from "../typechain-types";
-
-const owner = zksync.Wallet.createRandom();
-const guardian = zksync.Wallet.createRandom();
-const { deployer, provider } = getDeployer();
+import { deployer, guardian, owner, provider } from "./fixtures";
 
 describe("Paymaster tests", () => {
   let argent: ArgentInfrastructure;

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -1,29 +1,27 @@
-import "@nomicfoundation/hardhat-chai-matchers";
-import "@nomiclabs/hardhat-ethers";
 import { expect } from "chai";
-import { ethers } from "hardhat";
 import * as zksync from "zksync-web3";
 import { TransactionResponse } from "zksync-web3/build/src/types";
 import { connect, deployAccount } from "../src/account.service";
-import { checkDeployer, getDeployer } from "../src/deployer.service";
+import { checkDeployer } from "../src/deployer.service";
 import { getTestInfrastructure } from "../src/infrastructure.service";
 import { ArgentInfrastructure } from "../src/model";
 import { waitForL1BatchBlock, waitForTimestamp } from "../src/provider.service";
 import { ArgentAccount } from "../typechain-types";
+import {
+  AddressZero,
+  deployer,
+  guardian,
+  guardianAddress,
+  owner,
+  ownerAddress,
+  provider,
+  wrongGuardian,
+  wrongOwner,
+} from "./fixtures";
 
-const { AddressZero } = ethers.constants;
-
-const owner = zksync.Wallet.createRandom();
-const guardian = zksync.Wallet.createRandom();
 const newOwner = zksync.Wallet.createRandom();
 const newGuardian = zksync.Wallet.createRandom();
 const newGuardianBackup = zksync.Wallet.createRandom();
-const wrongOwner = zksync.Wallet.createRandom();
-const wrongGuardian = zksync.Wallet.createRandom();
-
-const ownerAddress = owner.address;
-const guardianAddress = guardian.address;
-const { deployer, provider } = getDeployer();
 
 describe("Recovery", () => {
   let argent: ArgentInfrastructure;

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,24 +1,22 @@
-import "@nomicfoundation/hardhat-chai-matchers";
-import "@nomiclabs/hardhat-ethers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import * as zksync from "zksync-web3";
 import { deployAccount } from "../src/account.service";
-import { checkDeployer, getDeployer } from "../src/deployer.service";
+import { checkDeployer } from "../src/deployer.service";
 import { getTestInfrastructure } from "../src/infrastructure.service";
 import { ArgentInfrastructure } from "../src/model";
 import { ArgentSigner, Signatory } from "../src/signer.service";
 import { ArgentAccount } from "../typechain-types";
-
-const { AddressZero } = ethers.constants;
-
-const owner = zksync.Wallet.createRandom();
-const guardian = zksync.Wallet.createRandom();
-const wrongGuardian = zksync.Wallet.createRandom();
-
-const ownerAddress = owner.address;
-const guardianAddress = guardian.address;
-const { deployer, provider } = getDeployer();
+import {
+  AddressZero,
+  deployer,
+  guardian,
+  guardianAddress,
+  owner,
+  ownerAddress,
+  provider,
+  wrongGuardian,
+} from "./fixtures";
 
 const eip1271MagicValue = zksync.utils.EIP1271_MAGIC_VALUE;
 


### PR DESCRIPTION
Reduces boilerplate in test suites to more easily spread tests across multiple files