### PR TITLE
Simplify signature substitution during estimation

### DIFF
--- a/contracts/ArgentAccount.sol
+++ b/contracts/ArgentAccount.sol
@@ -502,13 +502,10 @@ contract ArgentAccount is IAccount, IProxy, IMulticall, IERC165, IERC1271 {
         // in gas estimation mode, we're called with a single signature filled with zeros
         // substituting the signature with some signature-like array to make sure that the
         // validation step uses as much steps as the validation with the correct signature provided
-        uint256 requiredLength = _requiredSignatureLength(selector);
-        if (signature.length < requiredLength) {
-            signature = new bytes(requiredLength);
+        if (signature.length < _requiredSignatureLength(selector)) {
+            signature = new bytes(Signatures.DOUBLE_LENGTH);
             signature[Signatures.SINGLE_LENGTH - 1] = bytes1(uint8(27));
-            if (requiredLength == 2 * Signatures.SINGLE_LENGTH) {
-                signature[(2 * Signatures.SINGLE_LENGTH) - 1] = bytes1(uint8(27));
-            }
+            signature[Signatures.DOUBLE_LENGTH - 1] = bytes1(uint8(27));
             canBeValid = false;
         }
 
@@ -600,7 +597,7 @@ contract ArgentAccount is IAccount, IProxy, IMulticall, IERC165, IERC1271 {
         if (guardian == address(0) || _isOwnerEscapeCall(_selector) || _isGuardianEscapeCall(_selector)) {
             return Signatures.SINGLE_LENGTH;
         }
-        return 2 * Signatures.SINGLE_LENGTH;
+        return Signatures.DOUBLE_LENGTH;
     }
 
     function _isValidOwnerSignature(bytes32 _hash, bytes memory _ownerSignature) private view returns (bool) {

--- a/contracts/Signatures.sol
+++ b/contracts/Signatures.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.18;
 
 library Signatures {
     uint256 public constant SINGLE_LENGTH = 65;
+    uint256 public constant DOUBLE_LENGTH = 2 * SINGLE_LENGTH;
 
     /// Non-reverting version of ECDSA.recover that returns address(0) if anything is invalid
     function recoverSigner(bytes32 _hash, bytes memory _signature) internal pure returns (address) {
@@ -50,7 +51,7 @@ library Signatures {
             return (_fullSignature, _signature2);
         }
 
-        require(_fullSignature.length == 2 * SINGLE_LENGTH, "argent/invalid-signature-length");
+        require(_fullSignature.length == DOUBLE_LENGTH, "argent/invalid-signature-length");
         _signature1 = new bytes(SINGLE_LENGTH);
         _signature2 = new bytes(SINGLE_LENGTH);
 


### PR DESCRIPTION
`[0, 0, ..., 27]` is already passed during estimation, only need to update when expecting double signature