### PR TITLE
Only output relevant logs in `yarn start`

### DIFF
--- a/bin/start-dev-node.sh
+++ b/bin/start-dev-node.sh
@@ -5,4 +5,4 @@
 set -e # stop the script if any subprocess fails
 
 cd local-setup
-./start.sh | grep --invert-match '^local-setup-geth'
+./start.sh 2>&1 | grep --invert-match 'local-setup-geth-1'


### PR DESCRIPTION
Helps notice errors better